### PR TITLE
chore: mvvmlight 지원 중단으로 MS MVVM ToolKit으로 마이그레이션

### DIFF
--- a/AccountManager/AccountManager.csproj
+++ b/AccountManager/AccountManager.csproj
@@ -126,14 +126,14 @@
     <None Include="App.config" />
   </ItemGroup>
   <ItemGroup>
+    <PackageReference Include="Microsoft.Toolkit.Mvvm">
+      <Version>7.1.2</Version>
+    </PackageReference>
     <PackageReference Include="Microsoft.Xaml.Behaviors.Wpf">
       <Version>1.1.31</Version>
     </PackageReference>
     <PackageReference Include="ModernWpfUI">
       <Version>0.9.4</Version>
-    </PackageReference>
-    <PackageReference Include="MvvmLight">
-      <Version>5.4.1.1</Version>
     </PackageReference>
     <PackageReference Include="Newtonsoft.Json">
       <Version>13.0.1</Version>

--- a/AccountManager/Model/Account.cs
+++ b/AccountManager/Model/Account.cs
@@ -1,4 +1,4 @@
-﻿using GalaSoft.MvvmLight;
+﻿using Microsoft.Toolkit.Mvvm.ComponentModel;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -7,50 +7,34 @@ using System.Threading.Tasks;
 
 namespace AccountManager.Model
 {
-    public class Account : ViewModelBase
+    public class Account : ObservableObject 
     {
         private string site_;
         public string Site
         {
             get => site_;
-            set
-            {
-                site_ = value;
-                RaisePropertyChanged(() => Site);
-            }
+            set => SetProperty(ref site_, value);
         }
 
         public string id_;
         public string Id
         {
             get => id_;
-            set
-            {
-                id_ = value;
-                RaisePropertyChanged(() => Id);
-            }
+            set => SetProperty(ref id_, value);
         }
 
         public string password_;
         public string Password
         {
             get => password_;
-            set
-            {
-                password_ = value;
-                RaisePropertyChanged(() => Password);
-            }
+            set => SetProperty(ref password_, value);
         }
 
         public string description_;
         public string Description
         {
             get => description_;
-            set
-            {
-                description_ = value;
-                RaisePropertyChanged(() => Description);
-            }
+            set => SetProperty(ref description_, value);
         }
 
         public Account Clone()

--- a/AccountManager/ViewModel/MainWindowViewModel.cs
+++ b/AccountManager/ViewModel/MainWindowViewModel.cs
@@ -1,8 +1,8 @@
 ﻿using AccountManager.Model;
 using AccountManager.Util;
 using AccountManager.View;
-using GalaSoft.MvvmLight;
-using GalaSoft.MvvmLight.CommandWpf;
+using Microsoft.Toolkit.Mvvm.ComponentModel;
+using Microsoft.Toolkit.Mvvm.Input;
 using ModernWpf.Controls;
 using System;
 using System.Collections.Generic;
@@ -15,7 +15,7 @@ using System.Windows.Input;
 
 namespace AccountManager.ViewModel
 {
-    public class MainWindowViewModel : ViewModelBase
+    public class MainWindowViewModel : ObservableRecipient
     {
         public MainWindowViewModel()
         {
@@ -70,22 +70,14 @@ namespace AccountManager.ViewModel
         public ObservableCollection<Account> Accounts
         {
             get => accounts_;
-            set
-            {
-                accounts_ = value;
-                RaisePropertyChanged(() => Accounts);
-            }
+            set => SetProperty(ref accounts_, value);
         }
 
         private ObservableCollection<Account> selectedAccounts_ = new ObservableCollection<Account>();
         public ObservableCollection<Account> SelectedAccounts
         {
             get => selectedAccounts_;
-            set
-            {
-                selectedAccounts_ = value;
-                RaisePropertyChanged(() => SelectedAccounts);
-            }
+            set => SetProperty(ref selectedAccounts_, value);
         }
 
         public ICommand AccountSelectionChanged
@@ -103,6 +95,8 @@ namespace AccountManager.ViewModel
                     {
                         SelectedAccounts.Remove(item);
                     }
+                    OnPropertyChanged(nameof(ChangeAccount));
+                    OnPropertyChanged(nameof(DeleteAccount));
                 });
             }
         }

--- a/AccountManager/ViewModel/Popup/PasswordAskDialogViewModel.cs
+++ b/AccountManager/ViewModel/Popup/PasswordAskDialogViewModel.cs
@@ -1,5 +1,5 @@
-﻿using GalaSoft.MvvmLight;
-using GalaSoft.MvvmLight.CommandWpf;
+﻿using Microsoft.Toolkit.Mvvm.ComponentModel;
+using Microsoft.Toolkit.Mvvm.Input;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -10,7 +10,7 @@ using System.Windows.Input;
 
 namespace AccountManager.ViewModel
 {
-    public class PasswordAskDialogViewModel : ViewModelBase
+    public class PasswordAskDialogViewModel : ObservableRecipient
     {
         public string Password { get; private set; } = "";
 


### PR DESCRIPTION
특이사항
- MVVM ToolKit이 wpf 종속적인 동작을 포함하고 있지 않아 미묘한 차이가 발생함
- ex)  RelayCommand가 CommandManager.InvalidateRequerySuggested의 영향을 받지 않음

Resolves: #4